### PR TITLE
Microstructure tweak

### DIFF
--- a/Source/snowpack/snowpack/DataClasses.cc
+++ b/Source/snowpack/snowpack/DataClasses.cc
@@ -2607,7 +2607,7 @@ bool SnowStation::combineCondition(const ElementData& Edata0, const ElementData&
 			comb_thresh_rg_flex = comb_thresh_rg * 50.;
 		}
 	} else {
-		comb_thresh_rg_flex = (std::max(0., (depth - 1.) / scale) * comb_thresh_rg) + comb_thresh_rg;
+		comb_thresh_rg_flex = (std::max(0., (depth - 1.) / scale) * 4. * comb_thresh_rg) + comb_thresh_rg;
 	}
 
 	if ( fabs(Edata0.rg - Edata1.rg) > comb_thresh_rg_flex )

--- a/Source/snowpack/snowpack/Laws_sn.cc
+++ b/Source/snowpack/snowpack/Laws_sn.cc
@@ -1316,7 +1316,8 @@ double SnLaws::NewSnowViscosityLehning(const ElementData& Edata)
  */
 double SnLaws::snowViscosityTemperatureTerm(const double& Te)
 {
-	const double Q = 67000.; // Activation energy for defects in ice (J mol-1)
+	// Max Stevens concluded in presentation at AGU 2021 that models with activation energy 60 kJ/mol worked best for South Pole (see https://agu.confex.com/agu/fm21/meetingapp.cgi/Paper/947354)
+	const double Q = (current_variant == "POLAR" || current_variant == "ANTARCTICA") ? (60000.) :(67000.); // Activation energy for defects in ice (J mol-1)
 
 	switch (SnLaws::t_term) {
 	case t_term_arrhenius_critical:

--- a/Source/snowpack/snowpack/snowpackCore/Metamorphism.h
+++ b/Source/snowpack/snowpack/snowpackCore/Metamorphism.h
@@ -78,6 +78,7 @@ class Metamorphism {
 		static std::map<std::string, MetaSpRateFn> mapSpRate;
 
 		const std::string metamorphism_model;
+		const std::string variant;
 		const double sn_dt, new_snow_grain_size;
 };
 


### PR DESCRIPTION
Some changes to the microstructure treatment and setting activation energy == 60 kJ/mol, to improve simulations for Polar regions. Settling is improved by removing the marker for crusts, and setting microstructure to rounded for layers above 550 kg/m3 dry density, when layers are older than 1 year.